### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ado24/NAD-C338-REST-API/security/code-scanning/18](https://github.com/ado24/NAD-C338-REST-API/security/code-scanning/18)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only needs to read the repository contents (e.g., to check out the code), we will set `contents: read`. This ensures that the workflow adheres to the principle of least privilege and does not grant unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
